### PR TITLE
Implemented AuditLog entity, repository interface and class

### DIFF
--- a/src/Api/Controllers/AuditLogsController.cs
+++ b/src/Api/Controllers/AuditLogsController.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Application.AuditLogs.Commands.Create;
+using Application.AuditLogs.Queries.QueryByEntityId;
+using Contracts.AuditLogs;
+using Domain.Audit;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Controllers;
+[Route("api/v{v:apiVersion}/auditlogs")]
+[ApiController]
+public class AuditLogsController(IMediator _mediator) : ControllerBase
+{
+	[ProducesResponseType(typeof(AuditLog), StatusCodes.Status200OK)]
+	[HttpPost]
+	public async Task<IActionResult> Create(CreateAuditLogRequest request)
+	{
+		var auditLog = await _mediator.Send(new CreateAuditLogCommand(request));
+		return Ok(auditLog);
+	}
+
+	[ProducesResponseType(typeof(List<AuditLog>), StatusCodes.Status200OK)]
+	[HttpGet("{entityType}/{entityId}")]
+	public async Task<IActionResult> GetOnEntityId(string entityType, string entityId)
+	{
+		var messages = await _mediator.Send(new AuditLogsOnEntityIdQuery(entityType, entityId));
+		return Ok(messages);
+	}
+}

--- a/src/Application/AuditLogs/Commands/Create/CreateAuditLogCommand.cs
+++ b/src/Application/AuditLogs/Commands/Create/CreateAuditLogCommand.cs
@@ -1,0 +1,10 @@
+﻿using Contracts.AuditLogs;
+using Domain.Audit;
+using ErrorOr;
+using MediatR;
+
+namespace Application.AuditLogs.Commands.Create;
+public record CreateAuditLogCommand(CreateAuditLogRequest Request)
+	: IRequest<ErrorOr<AuditLog>>
+{
+}

--- a/src/Application/AuditLogs/Commands/Create/CreateAuditLogCommandHandler.cs
+++ b/src/Application/AuditLogs/Commands/Create/CreateAuditLogCommandHandler.cs
@@ -1,0 +1,29 @@
+﻿using Application.Common.Interfaces;
+using Domain.Audit;
+using ErrorOr;
+using MediatR;
+
+namespace Application.AuditLogs.Commands.Create;
+public class CreateAuditLogCommandHandler(IAuditLogsRepository repo)
+	: IRequestHandler<CreateAuditLogCommand, ErrorOr<AuditLog>>
+{
+	public async Task<ErrorOr<AuditLog>> Handle(CreateAuditLogCommand command, CancellationToken cancellationToken)
+	{
+		var auditLog = new AuditLog()
+		{
+			Id = Guid.NewGuid(),
+			CreateTime = DateTimeOffset.Now,
+			CorrelationId = Guid.NewGuid(),
+			EntityType = command.Request.EntityType,
+			EntityId = command.Request.EntityId,
+			ChangedByCommand = command.Request.ChangedByCommand,
+			CommandId = command.Request.CommandId,
+			ChangedByUser = command.Request.ChangedByUser,
+			Content = command.Request.Content
+		};
+
+		await repo.CreateAuditLog(auditLog);
+
+		return auditLog;
+	}
+}

--- a/src/Application/AuditLogs/Queries/QueryByEntityId/AuditLogsOnEntityIdQuery.cs
+++ b/src/Application/AuditLogs/Queries/QueryByEntityId/AuditLogsOnEntityIdQuery.cs
@@ -1,0 +1,10 @@
+﻿using Contracts.AuditLogs;
+using Domain.Audit;
+using ErrorOr;
+using MediatR;
+
+namespace Application.AuditLogs.Queries.QueryByEntityId;
+public record AuditLogsOnEntityIdQuery(string EntityType, string EntityId)
+	: IRequest<ErrorOr<List<AuditLog>>>
+{
+}

--- a/src/Application/AuditLogs/Queries/QueryByEntityId/AuditLogsOnEntityIdQueryHandler.cs
+++ b/src/Application/AuditLogs/Queries/QueryByEntityId/AuditLogsOnEntityIdQueryHandler.cs
@@ -1,0 +1,14 @@
+﻿using Application.Common.Interfaces;
+using Domain.Audit;
+using ErrorOr;
+using MediatR;
+
+namespace Application.AuditLogs.Queries.QueryByEntityId;
+public class AuditLogsOnEntityIdQueryHandler(IAuditLogsRepository repo)
+	: IRequestHandler<AuditLogsOnEntityIdQuery, ErrorOr<List<AuditLog>>>
+{
+	public async Task<ErrorOr<List<AuditLog>>> Handle(AuditLogsOnEntityIdQuery query, CancellationToken cancellationToken)
+	{
+		return await repo.GetAuditLogsForEntity(query.EntityType, query.EntityId);
+	}
+}

--- a/src/Application/Common/Interfaces/IAuditLogsRepository.cs
+++ b/src/Application/Common/Interfaces/IAuditLogsRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Audit;
+
+namespace Application.Common.Interfaces;
+public interface IAuditLogsRepository
+{
+	Task CreateAuditLog(AuditLog auditLog);
+	Task<List<AuditLog>> GetAuditLogsForEntity(string entityType, string entityId);
+}

--- a/src/Contracts/AuditLogs/CreateAuditLogRequest.cs
+++ b/src/Contracts/AuditLogs/CreateAuditLogRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace Contracts.AuditLogs;
+public record CreateAuditLogRequest
+{
+	// Specific information
+	public required string EntityType { get; set; }
+	public required string EntityId { get; set; }
+	public string? ChangedByCommand { get; set; }
+	public string? CommandId { get; set; }
+	public string? ChangedByUser { get; set; }
+	public required string Content { get; set; }
+}

--- a/src/Domain/Audit/AuditLog.cs
+++ b/src/Domain/Audit/AuditLog.cs
@@ -1,0 +1,18 @@
+﻿namespace Domain.Audit;
+
+public class AuditLog
+{
+	// Base information
+	public Guid Id { get; set; }
+	public DateTimeOffset CreateTime { get; set; }
+	public DateTimeOffset UpdateTime { get; set; }
+	public Guid CorrelationId { get; set; }
+
+	// Specific information
+	public required string EntityType { get; set; }
+	public required string EntityId { get; set; }
+	public string? ChangedByCommand { get; set; }
+	public string? CommandId { get; set; }
+	public string? ChangedByUser { get; set; }
+	public required string Content {  get; set; }	
+}

--- a/src/Infrastructure/AuditLogs/Persistence/AuditLogsRepository.cs
+++ b/src/Infrastructure/AuditLogs/Persistence/AuditLogsRepository.cs
@@ -1,0 +1,22 @@
+﻿using Application.Common.Interfaces;
+using Domain.Audit;
+using Infrastructure.Common.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.AuditLogs.Persistence;
+public class AuditLogsRepository(AppDbContext _dbContext) : IAuditLogsRepository
+{
+	public async Task CreateAuditLog(AuditLog auditLog)
+	{
+		await _dbContext.AuditLogs.AddAsync(auditLog);
+		await _dbContext.SaveChangesAsync();
+	}
+
+	public async Task<List<AuditLog>> GetAuditLogsForEntity(string entityType, string entityId)
+	{
+		return await _dbContext.AuditLogs
+			.Where(x => x.EntityType == entityType && x.EntityId == entityId)
+			.OrderBy(x => x.CreateTime)
+			.ToListAsync();
+	}
+}

--- a/src/Infrastructure/Common/Persistence/AppDbContext.cs
+++ b/src/Infrastructure/Common/Persistence/AppDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Domain.Identity;
+﻿using Domain.Audit;
+using Domain.Identity;
 using Domain.Messages;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ namespace Infrastructure.Common.Persistence;
 public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbContext<ApplicationUser, ApplicationRole, string>(options)
 {
 	public DbSet<Message> Messages { get; set; }
+	public DbSet<AuditLog> AuditLogs { get; set; }
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{


### PR DESCRIPTION
This PR will implement Auditlogging on entities. This Auditlogging is custom made and therefore it is not integrated with EFCore. It is possible to get all the different auditlogs for a certain entity, by providing the entitytype and id. Auditlogging should happen each time a change happens to an entity. This should be setup with events in the Application layer, You can also create a manual auditlog using an API endpoint.